### PR TITLE
Fix: Download rotjs from a CDN and pin version

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <title>Tiny Tale</title>
-        <script src="https://ondras.github.io/rot.js/rot.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/rot.js/0.6.0/rot.min.js"></script>
         <script src="src/Color.js"></script>
         <script src="src/Content.js"></script>
         <script src="src/Display.js"></script>


### PR DESCRIPTION
The library was fetched from ondras.github.io, i.e the personal website of the library author. The js file itself probably moved at some point, so the lib request was returning _404_ and therefore broke tiny-tale (see screenshot)

![image](https://user-images.githubusercontent.com/2179169/66257261-dff50c00-e796-11e9-9ffe-020a9b3c4be9.png)
